### PR TITLE
Update fetch.rs

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -37,9 +37,9 @@ pub fn found_videos(
         handlers.push(handler);
         return Ok(());
     }
-
-    if depth == 0 {
-        return Ok(());
+    
+    if depth==0 || path.is_file() {
+        return Ok(())
     }
 
     for i in path.read_dir()? {


### PR DESCRIPTION
对于这样一个结构的目录，ranger ./textdir/ --depth 2会报错，原因是没有正确过滤something.abc
testdir/
├── something.abc
├── test
│   └── 黑客帝国.rmvb
└── 低俗小说.rmvb